### PR TITLE
Refactor X509CertStore to implement ICertificateRepository

### DIFF
--- a/src/LetsEncrypt/Internal/ICertificateStore.cs
+++ b/src/LetsEncrypt/Internal/ICertificateStore.cs
@@ -8,6 +8,5 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
     internal interface ICertificateStore
     {
         X509Certificate2? GetCertificate(string domainName);
-        void Save(X509Certificate2 certificate);
     }
 }

--- a/src/LetsEncrypt/Internal/X509CertStore.cs
+++ b/src/LetsEncrypt/Internal/X509CertStore.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace McMaster.AspNetCore.LetsEncrypt.Internal
 {
-    internal class X509CertStore : ICertificateStore, IDisposable
+    internal class X509CertStore : ICertificateStore, ICertificateRepository, IDisposable
     {
         private readonly X509Store _store;
         private readonly ILogger<X509CertStore> _logger;
@@ -53,7 +55,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             return certWithMostTtl;
         }
 
-        public void Save(X509Certificate2 certificate)
+        public Task SaveAsync(X509Certificate2 certificate, CancellationToken cancellationToken)
         {
             try
             {
@@ -64,6 +66,8 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
                 _logger.LogError(0, ex, "Failed to save certificate to store");
                 throw;
             }
+
+            return Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
+++ b/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
@@ -45,7 +45,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<IHostedService, DeveloperCertLoader>()
                 .AddSingleton<IHostedService, AcmeCertificateLoader>()
                 .AddSingleton<IHttpChallengeResponseStore, InMemoryHttpChallengeResponseStore>()
-                .AddSingleton<ICertificateStore, X509CertStore>()
+                .AddSingleton<X509CertStore>()
+                .AddSingleton<ICertificateStore>(x => x.GetRequiredService<X509CertStore>())
+                .AddSingleton<ICertificateRepository>(x => x.GetRequiredService<X509CertStore>())
                 .AddSingleton<HttpChallengeResponseMiddleware>()
                 .AddSingleton<IStartupFilter, HttpChallengeStartupFilter>();
 


### PR DESCRIPTION
* Remove .Save from internal api ICertificateStore and refactor X509CertStore to use ICertificateRepository
* Move usages of ICertificateRepository out of CertificateFactory and into the AcmeCertificateLoader
* Add tests for writing a cert