### PR TITLE
Refactor cert selector to read domain names from the X509Cert object

### DIFF
--- a/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
@@ -121,10 +121,8 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             var factory = new CertificateFactory(_options, _challengeStore, _logger, _hostEnvironment);
 
             var cert = await GetOrCreateCertificate(factory, cancellationToken);
-            foreach (var domainName in _options.Value.DomainNames)
-            {
-                _selector.Use(domainName, cert);
-            }
+
+            _selector.Add(cert);
 
             var saveTasks = new List<Task>
             {

--- a/src/LetsEncrypt/Internal/DeveloperCertLoader.cs
+++ b/src/LetsEncrypt/Internal/DeveloperCertLoader.cs
@@ -60,7 +60,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             else
             {
                 _logger.LogDebug("Using the " + AspNetHttpsOidFriendlyName + " for 'localhost' requests");
-                _certSelector.Use("localhost", certs[0]);
+                _certSelector.Add(certs[0]);
             }
         }
 

--- a/src/LetsEncrypt/Internal/StartupCertificateLoader.cs
+++ b/src/LetsEncrypt/Internal/StartupCertificateLoader.cs
@@ -29,7 +29,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
 
                 foreach (var cert in certs)
                 {
-                    _selector.Use(string.Empty, cert);
+                    _selector.Add(cert);
                 }
             }
         }

--- a/src/LetsEncrypt/Internal/X509CertificateHelpers.cs
+++ b/src/LetsEncrypt/Internal/X509CertificateHelpers.cs
@@ -1,0 +1,164 @@
+// Copying liberally from https://github.com/dotnet/wcf/blob/811e3290ecf0b9a1a2a412e8e584caf44a7b3a29/src/System.Private.ServiceModel/src/System/IdentityModel/Claims/X509CertificateClaimSet.cs
+// Hopefully unnecessary one day - https://github.com/dotnet/corefx/issues/22068
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+
+namespace McMaster.AspNetCore.LetsEncrypt.Internal
+{
+    internal static class X509CertificateHelpers
+    {
+        public static string[] GetDnsFromExtensions(X509Certificate2 cert)
+        {
+            foreach (var ext in cert.Extensions)
+            {
+                // Extension is SAN2
+                if (ext.Oid.Value == X509SubjectAlternativeNameConstants.Oid)
+                {
+                    var asnString = ext.Format(false);
+                    if (string.IsNullOrWhiteSpace(asnString))
+                    {
+                        return Array.Empty<string>();
+                    }
+
+                    // SubjectAlternativeNames might contain something other than a dNSName,
+                    // so we have to parse through and only use the dNSNames
+                    // <identifier><delimter><value><separator(s)>
+
+                    var rawDnsEntries =
+                        asnString.Split(new string[1] { X509SubjectAlternativeNameConstants.Separator }, StringSplitOptions.RemoveEmptyEntries);
+
+                    var dnsEntries = new List<string>();
+
+                    for (var i = 0; i < rawDnsEntries.Length; i++)
+                    {
+                        var keyval = rawDnsEntries[i].Split(X509SubjectAlternativeNameConstants.Delimiter);
+                        if (string.Equals(keyval[0], X509SubjectAlternativeNameConstants.Identifier, StringComparison.Ordinal))
+                        {
+                            dnsEntries.Add(keyval[1]);
+                        }
+                    }
+
+                    return dnsEntries.ToArray();
+                }
+            }
+            return Array.Empty<string>();
+        }
+
+        // We don't have a strongly typed extension to parse Subject Alt Names, so we have to do a workaround
+        // to figure out what the identifier, delimiter, and separator is by using a well-known extension
+        private static class X509SubjectAlternativeNameConstants
+        {
+            public const string Oid = "2.5.29.17";
+
+            private static readonly string? s_identifier;
+            private static readonly char s_delimiter;
+            private static readonly string? s_separator;
+
+            private static bool s_successfullyInitialized = false;
+            private static Exception? s_initializationException;
+
+            public static string Identifier
+            {
+                get
+                {
+                    EnsureInitialized();
+                    return s_identifier!;
+                }
+            }
+
+            public static char Delimiter
+            {
+                get
+                {
+                    EnsureInitialized();
+                    return s_delimiter;
+                }
+            }
+            public static string Separator
+            {
+                get
+                {
+                    EnsureInitialized();
+                    return s_separator!;
+                }
+            }
+
+            private static void EnsureInitialized()
+            {
+                if (!s_successfullyInitialized)
+                {
+                    throw new FormatException(string.Format(
+                        CultureInfo.InvariantCulture,
+                        "There was an error detecting the identifier, delimiter, and separator for X509CertificateClaims on this platform.{0}" +
+                        "Detected values were: Identifier: '{1}'; Delimiter:'{2}'; Separator:'{3}'",
+                        Environment.NewLine,
+                        s_identifier,
+                        s_delimiter,
+                        s_separator
+                    ), s_initializationException);
+                }
+            }
+
+            // static initializer runs only when one of the properties is accessed
+            static X509SubjectAlternativeNameConstants()
+            {
+                // Extracted a well-known X509Extension
+                var x509ExtensionBytes = new byte[] {
+                    48, 36, 130, 21, 110, 111, 116, 45, 114, 101, 97, 108, 45, 115, 117, 98, 106, 101, 99,
+                    116, 45, 110, 97, 109, 101, 130, 11, 101, 120, 97, 109, 112, 108, 101, 46, 99, 111, 109
+                };
+                const string subjectName1 = "not-real-subject-name";
+
+                try
+                {
+                    var x509Extension = new X509Extension(Oid, x509ExtensionBytes, true);
+                    var x509ExtensionFormattedString = x509Extension.Format(false);
+
+                    // Each OS has a different dNSName identifier and delimiter
+                    // On Windows, dNSName == "DNS Name" (localizable), on Linux, dNSName == "DNS"
+                    // e.g.,
+                    // Windows: x509ExtensionFormattedString is: "DNS Name=not-real-subject-name, DNS Name=example.com"
+                    // Linux:   x509ExtensionFormattedString is: "DNS:not-real-subject-name, DNS:example.com"
+                    // Parse: <identifier><delimter><value><separator(s)>
+
+                    var delimiterIndex = x509ExtensionFormattedString.IndexOf(subjectName1, StringComparison.Ordinal) - 1;
+                    s_delimiter = x509ExtensionFormattedString[delimiterIndex];
+
+                    // Make an assumption that all characters from the the start of string to the delimiter
+                    // are part of the identifier
+                    s_identifier = x509ExtensionFormattedString.Substring(0, delimiterIndex);
+
+                    var separatorFirstChar = delimiterIndex + subjectName1.Length + 1;
+                    var separatorLength = 1;
+                    for (var i = separatorFirstChar + 1; i < x509ExtensionFormattedString.Length; i++)
+                    {
+                        // We advance until the first character of the identifier to determine what the
+                        // separator is. This assumes that the identifier assumption above is correct
+                        if (x509ExtensionFormattedString[i] == s_identifier[0])
+                        {
+                            break;
+                        }
+
+                        separatorLength++;
+                    }
+
+                    s_separator = x509ExtensionFormattedString.Substring(separatorFirstChar, separatorLength);
+
+                    s_successfullyInitialized = true;
+                }
+                catch (Exception ex)
+                {
+                    s_successfullyInitialized = false;
+                    s_initializationException = ex;
+                }
+            }
+        }
+    }
+}

--- a/test/LetsEncrypt.UnitTests/CertificateSelectorTests.cs
+++ b/test/LetsEncrypt.UnitTests/CertificateSelectorTests.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+using McMaster.AspNetCore.LetsEncrypt;
+using McMaster.AspNetCore.LetsEncrypt.Internal;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LetsEncrypt.UnitTests
+{
+    using static TestUtils;
+
+    public class CertificateSelectorTests
+    {
+        [Fact]
+        public void ItUsesCertCommonName()
+        {
+            const string CommonName = "selector.letsencrypt.natemcmaster.com";
+
+            var testCert = CreateTestCert(CommonName);
+            var selector = new CertificateSelector(Options.Create(new LetsEncryptOptions()));
+
+            selector.Add(testCert);
+
+            var domain = Assert.Single(selector.SupportedDomains);
+            Assert.Equal(CommonName, domain);
+        }
+
+        [Fact]
+        public void ItUsesSubjectAlternativeName()
+        {
+            var domainNames = new[]
+            {
+                "san1.letsencrypt.natemcmaster.com",
+                "san2.letsencrypt.natemcmaster.com",
+                "san3.letsencrypt.natemcmaster.com",
+            };
+            var testCert = CreateTestCert(domainNames);
+            var selector = new CertificateSelector(Options.Create(new LetsEncryptOptions()));
+
+            selector.Add(testCert);
+
+
+            Assert.Equal(
+                new HashSet<string>(domainNames),
+                new HashSet<string>(selector.SupportedDomains));
+        }
+    }
+}

--- a/test/LetsEncrypt.UnitTests/StartupCertificateLoaderTests.cs
+++ b/test/LetsEncrypt.UnitTests/StartupCertificateLoaderTests.cs
@@ -20,7 +20,7 @@ namespace LetsEncrypt.UnitTests
 
             var selector = new Mock<CertificateSelector>(Options.Create(new LetsEncryptOptions()));
             selector
-                .Setup(s => s.Use(It.IsAny<string>(), testCert))
+                .Setup(s => s.Add(testCert))
                 .Verifiable();
 
             var source1 = CreateCertSource(certs);

--- a/test/LetsEncrypt.UnitTests/TestUtils.cs
+++ b/test/LetsEncrypt.UnitTests/TestUtils.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace LetsEncrypt.UnitTests
+{
+    internal class TestUtils
+    {
+        public static X509Certificate2 CreateTestCert(string commonName, DateTimeOffset? expires = null)
+            => CreateTestCert(new[] { commonName }, expires);
+
+        public static X509Certificate2 CreateTestCert(string[] domainNames, DateTimeOffset? expires = null)
+        {
+            expires ??= DateTimeOffset.Now.AddMinutes(10);
+            var key = RSA.Create(2048);
+            var csr = new CertificateRequest(
+                "CN=" + domainNames[0],
+                key,
+                HashAlgorithmName.SHA512,
+                RSASignaturePadding.Pkcs1);
+
+            if (domainNames.Length > 1)
+            {
+                var sanBuilder = new SubjectAlternativeNameBuilder();
+                foreach (var san in domainNames.Skip(1))
+                {
+                    sanBuilder.AddDnsName(san);
+                }
+
+                csr.CertificateExtensions.Add(sanBuilder.Build());
+            }
+
+            return csr.CreateSelfSigned(DateTimeOffset.Now.AddMinutes(-1), expires.Value);
+        }
+    }
+}

--- a/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace LetsEncrypt.UnitTests
 {
@@ -13,6 +14,13 @@ namespace LetsEncrypt.UnitTests
 
     public class X509CertStoreTests
     {
+        private readonly ITestOutputHelper _output;
+
+        public X509CertStoreTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Fact]
         public void ItFindsCertByCommonName()
         {
@@ -21,6 +29,9 @@ namespace LetsEncrypt.UnitTests
             x509store.Open(OpenFlags.ReadWrite);
             var testCert = CreateTestCert(commonName);
             x509store.Add(testCert);
+
+            _output.WriteLine($"Adding cert {testCert.Thumbprint} to My/CurrentUser");
+
             try
             {
                 using var certStore = new X509CertStore(NullLogger<X509CertStore>.Instance)
@@ -58,6 +69,8 @@ namespace LetsEncrypt.UnitTests
                     X509FindType.FindByThumbprint,
                     testCert.Thumbprint,
                     validOnly: false);
+
+                _output.WriteLine($"Searching for cert {testCert.Thumbprint} to My/CurrentUser");
 
                 var foundCert = Assert.Single(certificates);
 

--- a/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Xunit;
@@ -24,7 +25,7 @@ namespace LetsEncrypt.UnitTests
         [Fact]
         public void ItFindsCertByCommonName()
         {
-            var commonName = "x509store.read.letsencrypt.test.natemcmaster.com";
+            var commonName = Path.GetRandomFileName() + ".x509store.letsencrypt.test.natemcmaster.com";
             using var x509store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             x509store.Open(OpenFlags.ReadWrite);
             var testCert = CreateTestCert(commonName);
@@ -50,9 +51,9 @@ namespace LetsEncrypt.UnitTests
         }
 
         [Fact]
-        public async Task ItSavesCertifiates()
+        public async Task ItSavesCertificates()
         {
-            var commonName = "x509store.save.letsencrypt.test.natemcmaster.com";
+            var commonName = Path.GetRandomFileName() + ".x509store.letsencrypt.test.natemcmaster.com";
             var testCert = CreateTestCert(commonName);
             using var x509store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             x509store.Open(OpenFlags.ReadWrite);

--- a/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
@@ -1,14 +1,16 @@
 ﻿using McMaster.AspNetCore.LetsEncrypt.Internal;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Xunit;
 
 namespace LetsEncrypt.UnitTests
 {
+    using static TestUtils;
+
     public class X509CertStoreTests
     {
         [Fact]
@@ -21,9 +23,7 @@ namespace LetsEncrypt.UnitTests
             x509store.Add(testCert);
             try
             {
-                var logger = new Mock<ILogger<X509CertStore>>();
-                logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
-                using var certStore = new X509CertStore(logger.Object)
+                using var certStore = new X509CertStore(NullLogger<X509CertStore>.Instance)
                 {
                     AllowInvalidCerts = true
                 };
@@ -48,9 +48,7 @@ namespace LetsEncrypt.UnitTests
 
             try
             {
-                var logger = new Mock<ILogger<X509CertStore>>();
-                logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
-                using var certStore = new X509CertStore(logger.Object)
+                using var certStore = new X509CertStore(NullLogger<X509CertStore>.Instance)
                 {
                     AllowInvalidCerts = true
                 };
@@ -112,18 +110,6 @@ namespace LetsEncrypt.UnitTests
                 x509store.Remove(testCert1);
                 x509store.Remove(testCert2);
             }
-        }
-
-        private X509Certificate2 CreateTestCert(string commonName, DateTimeOffset? expires = null)
-        {
-            expires ??= DateTimeOffset.Now.AddMinutes(2);
-            var key = RSA.Create(2048);
-            var csr = new CertificateRequest(
-                "CN=" + commonName,
-                key,
-                HashAlgorithmName.SHA512,
-                RSASignaturePadding.Pkcs1);
-            return csr.CreateSelfSigned(DateTimeOffset.Now.AddMinutes(-1), expires.Value);
         }
     }
 }


### PR DESCRIPTION
Follow-up to #41. The X509 cert itself contains all the info necessary to figure out which domains it can support. Use this instead of a separate parameter for DNS names.