### PR TITLE
fix: always use the certificate with the latest expiration date

### DIFF
--- a/test/LetsEncrypt.UnitTests/DeveloperCertLoaderTests.cs
+++ b/test/LetsEncrypt.UnitTests/DeveloperCertLoaderTests.cs
@@ -2,7 +2,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using McMaster.AspNetCore.LetsEncrypt.Internal;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -35,7 +34,7 @@ namespace LetsEncrypt.UnitTests
         [Fact]
         public async Task ItDoesNotLoadCertUnlessDevEnvironment()
         {
-             var env = new Mock<IHostEnvironment>();
+            var env = new Mock<IHostEnvironment>();
             env.SetupGet(e => e.EnvironmentName).Returns("Staging");
 
             var loader = new DeveloperCertLoader(env.Object, NullLogger<DeveloperCertLoader>.Instance);

--- a/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LetsEncrypt.UnitTests/X509CertStoreTests.cs
@@ -1,12 +1,11 @@
-﻿using McMaster.AspNetCore.LetsEncrypt.Internal;
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using McMaster.AspNetCore.LetsEncrypt.Internal;
 using McMaster.Extensions.Xunit;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using System;
-using System.IO;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
Follow up to #41 . There might be multiple certificates which support a given domain name. Choose the one that has the latest expiration date.