### PR TITLE
Fixups: allow passwordless pfx, code refactoring, and add more tests

### DIFF
--- a/src/LetsEncrypt/FileSystemPersistenceExtensions.cs
+++ b/src/LetsEncrypt/FileSystemPersistenceExtensions.cs
@@ -13,13 +13,16 @@ namespace McMaster.AspNetCore.LetsEncrypt
     public static class FileSystemStorageExtensions
     {
         /// <summary>
-        /// Save generated certificates to
+        /// Save generated certificates to a directory in the .pfx format.
         /// </summary>
         /// <param name="builder"></param>
-        /// <param name="directory"></param>
-        /// <param name="pfxPassword"></param>
+        /// <param name="directory">The directory where .pfx files will be saved.</param>
+        /// <param name="pfxPassword">Set to null or empty for passwordless .pfx files.</param>
         /// <returns></returns>
-        public static ILetsEncryptServiceBuilder PersistCertificatesToDirectory(this ILetsEncryptServiceBuilder builder, DirectoryInfo directory, string pfxPassword)
+        public static ILetsEncryptServiceBuilder PersistCertificatesToDirectory(
+            this ILetsEncryptServiceBuilder builder,
+            DirectoryInfo directory,
+            string? pfxPassword)
         {
             if (builder is null)
             {
@@ -29,11 +32,6 @@ namespace McMaster.AspNetCore.LetsEncrypt
             if (directory is null)
             {
                 throw new ArgumentNullException(nameof(directory));
-            }
-
-            if (string.IsNullOrEmpty(pfxPassword))
-            {
-                throw new ArgumentException("Certificate password should be non-empty.", nameof(pfxPassword));
             }
 
             builder.Services.AddSingleton<ICertificateRepository>(new FileSystemCertificateRepository(directory, pfxPassword));

--- a/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
@@ -155,8 +155,12 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
 
             try
             {
-                _logger.LogInformation("Creating certificate for {hostname} using ACME server {acmeServer}", domainName, _options.Value.GetAcmeServer(_hostEnvironment));
+                _logger.LogInformation("Creating certificate for {hostname} using ACME server {acmeServer}",
+                    domainName,
+                    factory.AcmeServer);
+
                 cert = await factory.CreateCertificateAsync(cancellationToken);
+
                 _logger.LogInformation("Created certificate {subjectName} ({thumbprint})", cert.Subject, cert.Thumbprint);
                 return cert;
             }

--- a/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
+++ b/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
@@ -10,10 +10,10 @@ namespace McMaster.AspNetCore.LetsEncrypt
 {
     internal class FileSystemCertificateRepository : ICertificateRepository
     {
-        private readonly string _pfxPassword;
+        private readonly string? _pfxPassword;
         private readonly DirectoryInfo _directory;
 
-        public FileSystemCertificateRepository(DirectoryInfo directory, string pfxPassword)
+        public FileSystemCertificateRepository(DirectoryInfo directory, string? pfxPassword)
         {
             _pfxPassword = pfxPassword;
             _directory = directory;

--- a/src/LetsEncrypt/Internal/HttpChallengeResponseMiddleware.cs
+++ b/src/LetsEncrypt/Internal/HttpChallengeResponseMiddleware.cs
@@ -37,7 +37,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
 
             _logger.LogDebug("Confirmed challenge request for {token}", token);
 
-            context.Response.ContentLength = value.Length;
+            context.Response.ContentLength = value?.Length ?? 0;
             context.Response.ContentType = "application/octet-stream";
             await context.Response.WriteAsync(value, context.RequestAborted);
         }

--- a/src/LetsEncrypt/Internal/IHttpChallengeResponseStore.cs
+++ b/src/LetsEncrypt/Internal/IHttpChallengeResponseStore.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace McMaster.AspNetCore.LetsEncrypt.Internal
 {
     internal interface IHttpChallengeResponseStore
     {
         void AddChallengeResponse(string token, string response);
 
-        bool TryGetResponse(string token, out string value);
+        bool TryGetResponse(string token, [MaybeNullWhen(false)] out string? value);
     }
 }

--- a/src/LetsEncrypt/Internal/InMemoryHttpChallengeStore.cs
+++ b/src/LetsEncrypt/Internal/InMemoryHttpChallengeStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace McMaster.AspNetCore.LetsEncrypt.Internal
 {
@@ -13,11 +14,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
         public void AddChallengeResponse(string token, string response)
             => _values.AddOrUpdate(token, response, (_, __) => response);
 
-#pragma warning disable CS8601
-        // it seems like there is a bug in C# 8 with out parameters which causes a warning here that I can't figure
-        // out how to resolve, so suppressing and moving on.
-        public bool TryGetResponse(string token, out string value)
+        public bool TryGetResponse(string token, [MaybeNullWhen(false)] out string? value)
             => _values.TryGetValue(token, out value);
-#pragma warning restore CS8601
     }
 }

--- a/src/LetsEncrypt/Internal/X509CertificateHelpers.cs
+++ b/src/LetsEncrypt/Internal/X509CertificateHelpers.cs
@@ -61,8 +61,8 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             private static readonly char s_delimiter;
             private static readonly string? s_separator;
 
-            private static bool s_successfullyInitialized = false;
-            private static Exception? s_initializationException;
+            private static readonly bool s_successfullyInitialized = false;
+            private static readonly Exception? s_initializationException;
 
             public static string Identifier
             {

--- a/src/LetsEncrypt/LetsEncryptOptions.cs
+++ b/src/LetsEncrypt/LetsEncryptOptions.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
-using Certes.Acme;
-using Microsoft.Extensions.Hosting;
 
 #if NETSTANDARD2_0
 using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
@@ -17,8 +15,8 @@ namespace McMaster.AspNetCore.LetsEncrypt
     /// </summary>
     public class LetsEncryptOptions
     {
-        private Uri? _acmeServer;
         private string[] _domainNames = Array.Empty<string>();
+        private bool? _useStagingServer;
 
         /// <summary>
         /// The domain names for which to generate certificates.
@@ -51,11 +49,11 @@ namespace McMaster.AspNetCore.LetsEncrypt
         /// </summary>
         public bool UseStagingServer
         {
-            get => _acmeServer == WellKnownServers.LetsEncryptStaging;
-            set => _acmeServer = value
-                   ? WellKnownServers.LetsEncryptStagingV2
-                   : WellKnownServers.LetsEncryptV2;
+            get => _useStagingServer ?? false;
+            set => _useStagingServer = value;
         }
+
+        internal bool UseStagingServerExplicitlySet => _useStagingServer.HasValue;
 
         /// <summary>
         /// A certificate to use if a certifcates cannot be created automatically.
@@ -69,21 +67,5 @@ namespace McMaster.AspNetCore.LetsEncrypt
         /// Asymetric encryption algorithm: RS256, ES256, ES384, ES512
         /// </summary>
         public KeyAlgorithm KeyAlgorithm { get; set; } = KeyAlgorithm.ES256;
-
-        /// <summary>
-        /// The uri to the server that implements the ACME protocol for certificate generation.
-        /// </summary>
-        /// <param name="env"></param>
-        internal Uri GetAcmeServer(IHostEnvironment env)
-        {
-            if (_acmeServer != null)
-            {
-                return _acmeServer;
-            }
-
-            return env.IsDevelopment()
-                ? WellKnownServers.LetsEncryptStagingV2
-                : WellKnownServers.LetsEncryptV2;
-        }
     }
 }

--- a/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
+++ b/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
@@ -55,16 +55,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IConfigureOptions<LetsEncryptOptions>>(services =>
             {
                 var config = services.GetService<IConfiguration?>();
-                var hostEnv = services.GetService<IHostEnvironment?>();
-                return new ConfigureOptions<LetsEncryptOptions>(options =>
-                    {
-                        if (hostEnv != null)
-                        {
-                            options.UseStagingServer = hostEnv.IsDevelopment();
-                        }
-
-                        config?.Bind("LetsEncrypt", options);
-                    });
+                return new ConfigureOptions<LetsEncryptOptions>(options => config?.Bind("LetsEncrypt", options));
             });
 
             services.Configure(configure);

--- a/src/LetsEncrypt/Properties/Nullable.netstandard.2.0.cs
+++ b/src/LetsEncrypt/Properties/Nullable.netstandard.2.0.cs
@@ -1,0 +1,17 @@
+﻿#if NETSTANDARD2_0
+// This code doesn't do anything, but makes C# 8 play nice with netstandard2.0 without
+// having to have a bunch of #if defs all over the place.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    internal class MaybeNullWhenAttribute : Attribute
+    {
+        public MaybeNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+}
+#endif

--- a/test/LetsEncrypt.UnitTests/CertificateFactoryTests.cs
+++ b/test/LetsEncrypt.UnitTests/CertificateFactoryTests.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Certes.Acme;
+using McMaster.AspNetCore.LetsEncrypt;
+using McMaster.AspNetCore.LetsEncrypt.Internal;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
+using Xunit;
+
+#if NETCOREAPP2_1
+using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
+using Environments = Microsoft.Extensions.Hosting.EnvironmentName;
+#endif
+
+namespace LetsEncrypt.UnitTests
+{
+    public class CertificateFactoryTests
+    {
+        public static TheoryData<string, Uri> EnvironmentToDefaultAcmeServer()
+        {
+            return new TheoryData<string, Uri>
+            {
+                { Environments.Development,  WellKnownServers.LetsEncryptStagingV2 },
+                { Environments.Staging,  WellKnownServers.LetsEncryptV2 },
+                { Environments.Production,  WellKnownServers.LetsEncryptV2 },
+                { null,  WellKnownServers.LetsEncryptV2 },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(EnvironmentToDefaultAcmeServer))]
+
+        public void UsesDefaultAcmeServerBasedOnEnvironmentName(string environmentName, Uri acmeServer)
+        {
+            var env = new HostingEnvironment
+            {
+                EnvironmentName = environmentName
+            };
+
+            Assert.Equal(
+                acmeServer,
+                CertificateFactory.GetAcmeServer(new LetsEncryptOptions(), env));
+        }
+
+
+        [Theory]
+        [InlineData("Development")]
+        [InlineData("Production")]
+        public void OverridesDefaultAcmeServer(string environmentName)
+        {
+            var env = new HostingEnvironment
+            {
+                EnvironmentName = environmentName
+            };
+
+            var useStaging = new LetsEncryptOptions
+            {
+                UseStagingServer = true,
+            };
+
+            Assert.Equal(
+                WellKnownServers.LetsEncryptStagingV2,
+                CertificateFactory.GetAcmeServer(useStaging, env));
+
+            var useProduction = new LetsEncryptOptions
+            {
+                UseStagingServer = false,
+            };
+
+            Assert.Equal(
+                WellKnownServers.LetsEncryptV2,
+                CertificateFactory.GetAcmeServer(useProduction, env));
+        }
+    }
+}

--- a/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
+++ b/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
@@ -1,22 +1,40 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
 using McMaster.AspNetCore.LetsEncrypt;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace LetsEncrypt.UnitTests
 {
+    using static TestUtils;
+
     public class FileSystemCertificateRepoTests
     {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public async Task ItCanSaveCertsWithoutPassword(string? password)
+        {
+            var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+            var repo = new FileSystemCertificateRepository(dir, password);
+            var cert = CreateTestCert("localhost");
+            var expectedFile = Path.Combine(dir.FullName, cert.Thumbprint + ".pfx");
+            await repo.SaveAsync(cert, default);
+
+            Assert.NotNull(new X509Certificate2(expectedFile));
+        }
+
         [Fact]
-        public async System.Threading.Tasks.Task ItCreatesCertOnDiskAsync()
+        public async Task ItCreatesCertOnDiskAsync()
         {
             var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
             var repo = new FileSystemCertificateRepository(dir, "testpassword");
-            var key = RSA.Create(2048);
-            var csr = new CertificateRequest("CN=localhost", key, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-            var cert = csr.CreateSelfSigned(DateTimeOffset.Now, DateTimeOffset.Now.AddHours(1));
+            var cert = CreateTestCert("localhost");
             var expectedFile = Path.Combine(dir.FullName, cert.Thumbprint + ".pfx");
 
             Assert.False(dir.Exists, "Directory should not exist yet created");
@@ -26,6 +44,22 @@ namespace LetsEncrypt.UnitTests
             dir.Refresh();
             Assert.True(dir.Exists, "Directory was created");
             Assert.True(File.Exists(expectedFile), "Cert exists");
+        }
+
+        [Fact]
+        public void DIConfiguresRepo()
+        {
+            var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+            var services = new ServiceCollection()
+                .AddLogging()
+                .AddLetsEncrypt()
+                .PersistCertificatesToDirectory(dir, "testpassword")
+                .Services
+                .BuildServiceProvider(validateScopes: true);
+
+            Assert.Single(
+                services.GetServices<ICertificateRepository>()
+                .OfType<FileSystemCertificateRepository>());
         }
     }
 }


### PR DESCRIPTION
* allow password-less .pfx files to be saved to disk - #4 
* cleanup implementation of ACME server selection
* fix suppressed code warning about nullable references
* add tests #6