### PR TITLE
Rename API to 'PersistDataToDirectory' to accommodate more kinds of data to be stored in the future

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ A few required options should be set, typically via the appsettings.json file.
 }
 ```
 
+## Additional options
+
+### Save generated certificates and account information to a directory
+
+```c#
+using McMaster.AspNetCore.LetsEncrypt;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services
+        .AddLetsEncrypt()
+        .PersistDataToDirectory(new DirectoryInfo("C:/data/LetsEncrypt/"), "Password123");
+}
+```
+
 ## Testing in development
 
 See the [developer docs](./test/Integration/) for details on how to test Let's Encrypt in a non-production environment.

--- a/samples/Web/Startup.cs
+++ b/samples/Web/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using McMaster.AspNetCore.LetsEncrypt;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/LetsEncrypt/FileSystemPersistenceExtensions.cs
+++ b/src/LetsEncrypt/FileSystemPersistenceExtensions.cs
@@ -13,13 +13,14 @@ namespace McMaster.AspNetCore.LetsEncrypt
     public static class FileSystemStorageExtensions
     {
         /// <summary>
-        /// Save generated certificates to a directory in the .pfx format.
+        /// Save Let's Encrypt data to a directory.
+        /// Certificates are stored in the .pfx (PKCS #12) format in a subdirectory of <paramref name="directory"/>.
         /// </summary>
         /// <param name="builder"></param>
-        /// <param name="directory">The directory where .pfx files will be saved.</param>
+        /// <param name="directory">The root directory for storing information. Information may be stored in subdirectories.</param>
         /// <param name="pfxPassword">Set to null or empty for passwordless .pfx files.</param>
         /// <returns></returns>
-        public static ILetsEncryptServiceBuilder PersistCertificatesToDirectory(
+        public static ILetsEncryptServiceBuilder PersistDataToDirectory(
             this ILetsEncryptServiceBuilder builder,
             DirectoryInfo directory,
             string? pfxPassword)

--- a/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
+++ b/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
@@ -11,17 +11,17 @@ namespace McMaster.AspNetCore.LetsEncrypt
     internal class FileSystemCertificateRepository : ICertificateRepository
     {
         private readonly string? _pfxPassword;
-        private readonly DirectoryInfo _directory;
+        private readonly DirectoryInfo _certDir;
 
         public FileSystemCertificateRepository(DirectoryInfo directory, string? pfxPassword)
         {
             _pfxPassword = pfxPassword;
-            _directory = directory;
+            _certDir = directory.CreateSubdirectory("certs");
         }
 
         public Task SaveAsync(X509Certificate2 certificate, CancellationToken cancellationToken)
         {
-            _directory.Create();
+            _certDir.Create();
 
             var tmpFile = Path.GetTempFileName();
             File.WriteAllBytes(
@@ -29,7 +29,7 @@ namespace McMaster.AspNetCore.LetsEncrypt
                 certificate.Export(X509ContentType.Pfx, _pfxPassword));
 
             var fileName = certificate.Thumbprint + ".pfx";
-            var output = Path.Combine(_directory.FullName, fileName);
+            var output = Path.Combine(_certDir.FullName, fileName);
 
             // File.Move is an atomic operation on most operating systems. By writing to a temporary file
             // first and then moving it, it avoids potential race conditions with readers.

--- a/src/LetsEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LetsEncrypt/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 McMaster.AspNetCore.LetsEncrypt.FileSystemStorageExtensions
 McMaster.AspNetCore.LetsEncrypt.ICertificateRepository
 McMaster.AspNetCore.LetsEncrypt.ICertificateRepository.SaveAsync(System.Security.Cryptography.X509Certificates.X509Certificate2 certificate, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
-static McMaster.AspNetCore.LetsEncrypt.FileSystemStorageExtensions.PersistCertificatesToDirectory(this McMaster.AspNetCore.LetsEncrypt.ILetsEncryptServiceBuilder builder, System.IO.DirectoryInfo directory, string pfxPassword) -> McMaster.AspNetCore.LetsEncrypt.ILetsEncryptServiceBuilder
+static McMaster.AspNetCore.LetsEncrypt.FileSystemStorageExtensions.PersistDataToDirectory(this McMaster.AspNetCore.LetsEncrypt.ILetsEncryptServiceBuilder builder, System.IO.DirectoryInfo directory, string pfxPassword) -> McMaster.AspNetCore.LetsEncrypt.ILetsEncryptServiceBuilder

--- a/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
+++ b/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
@@ -2,7 +2,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using McMaster.AspNetCore.LetsEncrypt;
@@ -23,7 +22,7 @@ namespace LetsEncrypt.UnitTests
             var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
             var repo = new FileSystemCertificateRepository(dir, password);
             var cert = CreateTestCert("localhost");
-            var expectedFile = Path.Combine(dir.FullName, cert.Thumbprint + ".pfx");
+            var expectedFile = Path.Combine(dir.FullName, "certs", cert.Thumbprint + ".pfx");
             await repo.SaveAsync(cert, default);
 
             Assert.NotNull(new X509Certificate2(expectedFile));
@@ -33,11 +32,11 @@ namespace LetsEncrypt.UnitTests
         public async Task ItCreatesCertOnDiskAsync()
         {
             var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+            Assert.False(dir.Exists, "Directory should not exist yet created");
+
             var repo = new FileSystemCertificateRepository(dir, "testpassword");
             var cert = CreateTestCert("localhost");
-            var expectedFile = Path.Combine(dir.FullName, cert.Thumbprint + ".pfx");
-
-            Assert.False(dir.Exists, "Directory should not exist yet created");
+            var expectedFile = Path.Combine(dir.FullName, "certs", cert.Thumbprint + ".pfx");
 
             await repo.SaveAsync(cert, default);
 
@@ -53,7 +52,7 @@ namespace LetsEncrypt.UnitTests
             var services = new ServiceCollection()
                 .AddLogging()
                 .AddLetsEncrypt()
-                .PersistCertificatesToDirectory(dir, "testpassword")
+                .PersistDataToDirectory(dir, "testpassword")
                 .Services
                 .BuildServiceProvider(validateScopes: true);
 


### PR DESCRIPTION
I'm anticipating we will need to store more kinds of data than just certificates. Changing this API to be a little more generic so we can re-use for storing other info, like account information.