### PR TITLE
Fixes to PersistDataWithDirectory

### DIFF
--- a/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
+++ b/src/LetsEncrypt/Internal/FileSystemCertificateRepository.cs
@@ -1,22 +1,42 @@
 ﻿// Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace McMaster.AspNetCore.LetsEncrypt
 {
-    internal class FileSystemCertificateRepository : ICertificateRepository
+    internal class FileSystemCertificateRepository : ICertificateRepository, ICertificateSource
     {
-        private readonly string? _pfxPassword;
         private readonly DirectoryInfo _certDir;
 
         public FileSystemCertificateRepository(DirectoryInfo directory, string? pfxPassword)
         {
-            _pfxPassword = pfxPassword;
+            RootDir = directory;
+            PfxPassword = pfxPassword;
             _certDir = directory.CreateSubdirectory("certs");
+        }
+
+        public DirectoryInfo RootDir { get; }
+        public string? PfxPassword { get; }
+
+        public Task<IEnumerable<X509Certificate2>> GetCertificatesAsync(CancellationToken cancellationToken)
+        {
+            var certs = new List<X509Certificate2>();
+            foreach (var file in _certDir.GetFiles("*.pfx"))
+            {
+                var cert = new X509Certificate2(
+                    fileName: file.FullName,
+                    password: PfxPassword);
+                certs.Add(cert);
+            }
+
+            return Task.FromResult(certs.AsEnumerable());
         }
 
         public Task SaveAsync(X509Certificate2 certificate, CancellationToken cancellationToken)
@@ -26,7 +46,7 @@ namespace McMaster.AspNetCore.LetsEncrypt
             var tmpFile = Path.GetTempFileName();
             File.WriteAllBytes(
                 tmpFile,
-                certificate.Export(X509ContentType.Pfx, _pfxPassword));
+                certificate.Export(X509ContentType.Pfx, PfxPassword));
 
             var fileName = certificate.Thumbprint + ".pfx";
             var output = Path.Combine(_certDir.FullName, fileName);

--- a/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
+++ b/test/LetsEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
@@ -6,7 +6,13 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using McMaster.AspNetCore.LetsEncrypt;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
 using Xunit;
+
+#if NETCOREAPP2_1
+using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
+#endif
 
 namespace LetsEncrypt.UnitTests
 {
@@ -29,7 +35,7 @@ namespace LetsEncrypt.UnitTests
         }
 
         [Fact]
-        public async Task ItCreatesCertOnDiskAsync()
+        public async Task ItCreatesDirectory()
         {
             var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
             Assert.False(dir.Exists, "Directory should not exist yet created");
@@ -45,11 +51,30 @@ namespace LetsEncrypt.UnitTests
             Assert.True(File.Exists(expectedFile), "Cert exists");
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("testpassword")]
+        public async Task ItRoundTripsCert(string? password)
+        {
+            var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+
+            var repo = new FileSystemCertificateRepository(dir, password);
+            var writeCert = CreateTestCert("localhost");
+
+            await repo.SaveAsync(writeCert, default);
+
+            var certs = await repo.GetCertificatesAsync(default);
+            var readCert = Assert.Single(certs);
+            Assert.NotSame(writeCert, readCert);
+            Assert.Equal(writeCert, readCert);
+        }
+
         [Fact]
         public void DIConfiguresRepo()
         {
             var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
             var services = new ServiceCollection()
+                .AddSingleton<IHostEnvironment, HostingEnvironment>()
                 .AddLogging()
                 .AddLetsEncrypt()
                 .PersistDataToDirectory(dir, "testpassword")
@@ -59,6 +84,59 @@ namespace LetsEncrypt.UnitTests
             Assert.Single(
                 services.GetServices<ICertificateRepository>()
                 .OfType<FileSystemCertificateRepository>());
+        }
+
+        [Fact]
+        public void MultipleCallsToDIWithSameInfoDoesNotDuplicate()
+        {
+            var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+
+            var provider = new ServiceCollection()
+                .AddSingleton<IHostEnvironment, HostingEnvironment>()
+                .AddLogging()
+                .AddLetsEncrypt()
+                .PersistDataToDirectory(dir, "")
+                .PersistDataToDirectory(dir, "")
+                .Services
+                .BuildServiceProvider(validateScopes: true);
+
+
+            Assert.Single(provider.GetServices<ICertificateRepository>().OfType<FileSystemCertificateRepository>());
+            Assert.Single(provider.GetServices<ICertificateSource>().OfType<FileSystemCertificateRepository>());
+        }
+
+        [Fact]
+        public void MultipleCallsToDIWithDirerentDirectory()
+        {
+            var dir1 = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+            var dir2 = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+
+            var provider = new ServiceCollection()
+                .AddSingleton<IHostEnvironment, HostingEnvironment>()
+                .AddLogging()
+                .AddLetsEncrypt()
+                .PersistDataToDirectory(dir1, "")
+                .PersistDataToDirectory(dir2, "")
+                .Services
+                .BuildServiceProvider(validateScopes: true);
+
+
+            Assert.Equal(2, provider.GetServices<ICertificateRepository>().OfType<FileSystemCertificateRepository>().Count());
+            Assert.Equal(2, provider.GetServices<ICertificateSource>().OfType<FileSystemCertificateRepository>().Count());
+        }
+
+        [Fact]
+        public void ThrowsIfMultipleCallsDIWithDifferentPassword()
+        {
+            var dir = new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, Path.GetRandomFileName()));
+
+            var provider = new ServiceCollection()
+                .AddSingleton<IHostEnvironment, HostingEnvironment>()
+                .AddLogging()
+                .AddLetsEncrypt()
+                .PersistDataToDirectory(dir, "one");
+
+            Assert.Throws<ArgumentException>(() => provider.PersistDataToDirectory(dir, "two"));
         }
     }
 }


### PR DESCRIPTION
* Ensure multiple calls to PersistDataWithDirectory to same directory doesn't cause a conflict
* Load certificates from directory when PersistDataWithDirectory is used