### PR TITLE
Implement TLS-ALPN-01 challenge verification

### DIFF
--- a/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LetsEncrypt/Internal/AcmeCertificateLoader.cs
@@ -41,6 +41,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
         private readonly IEnumerable<ICertificateRepository> _certificateRepositories;
         private readonly IClock _clock;
         private readonly IHostApplicationLifetime _applicationLifetime;
+        private readonly TlsAlpnChallengeResponder _tlsAlpnChallengeResponder;
         private const string ErrorMessage = "Failed to create certificate";
 
         public AcmeCertificateLoader(
@@ -55,6 +56,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             IEnumerable<ICertificateRepository> certificateRepositories,
             IClock clock,
             IHostApplicationLifetime applicationLifetime,
+            TlsAlpnChallengeResponder tlsAlpnChallengeResponder,
             IAccountStore? accountStore = default)
         {
             _selector = selector;
@@ -69,6 +71,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             _certificateRepositories = certificateRepositories;
             _clock = clock;
             _applicationLifetime = applicationLifetime;
+            _tlsAlpnChallengeResponder = tlsAlpnChallengeResponder;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -145,7 +148,8 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
                 _accountStore,
                 _logger,
                 _hostEnvironment,
-                _applicationLifetime);
+                _applicationLifetime,
+                _tlsAlpnChallengeResponder);
 
             var account = await factory.GetOrCreateAccountAsync(cancellationToken);
             _logger.LogInformation("Using Let's Encrypt account {accountId}", account.Id);

--- a/src/LetsEncrypt/Internal/CertificateFactory.cs
+++ b/src/LetsEncrypt/Internal/CertificateFactory.cs
@@ -30,6 +30,7 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
         private readonly IHttpChallengeResponseStore _challengeStore;
         private readonly IAccountStore _accountRepository;
         private readonly ILogger _logger;
+        private readonly TlsAlpnChallengeResponder _tlsAlpnChallengeResponder;
         private TaskCompletionSource<object?> _appStarted;
         private AcmeContext? _context;
         private IAccountContext? _accountContext;
@@ -41,12 +42,14 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             IAccountStore? accountRepository,
             ILogger logger,
             IHostEnvironment env,
-            IHostApplicationLifetime appLifetime)
+            IHostApplicationLifetime appLifetime,
+            TlsAlpnChallengeResponder tlsAlpnChallengeResponder)
         {
             _tosChecker = tosChecker;
             _options = options;
             _challengeStore = challengeStore;
             _logger = logger;
+            _tlsAlpnChallengeResponder = tlsAlpnChallengeResponder;
 
             _appStarted = new TaskCompletionSource<object?>();
             appLifetime.ApplicationStarted.Register(() => _appStarted.TrySetResult(null));
@@ -224,40 +227,56 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (_tlsAlpnChallengeResponder.IsEnabled)
+            {
+                await PrepareTlsAlpnChallengeResponseAsync(authorizationContext, domainName, cancellationToken);
+            }
+
             await PrepareHttpChallengeResponseAsync(authorizationContext, domainName, cancellationToken);
 
             var retries = 60;
             var delay = TimeSpan.FromSeconds(2);
 
-            while (retries > 0)
+            try
             {
-                retries--;
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                authorization = await authorizationContext.Resource();
-
-                _logger.LogAcmeAction("GetAuthorization");
-
-                switch (authorization.Status)
+                while (retries > 0)
                 {
-                    case AuthorizationStatus.Valid:
-                        return;
-                    case AuthorizationStatus.Pending:
-                        await Task.Delay(delay);
-                        continue;
-                    case AuthorizationStatus.Invalid:
-                        throw InvalidAuthorizationError(authorization);
-                    case AuthorizationStatus.Revoked:
-                        throw new InvalidOperationException($"The authorization to verify domainName '{domainName}' has been revoked.");
-                    case AuthorizationStatus.Expired:
-                        throw new InvalidOperationException($"The authorization to verify domainName '{domainName}' has expired.");
-                    default:
-                        throw new ArgumentOutOfRangeException("Unexpected response from server while validating domain ownership.");
+                    retries--;
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    authorization = await authorizationContext.Resource();
+
+                    _logger.LogAcmeAction("GetAuthorization");
+
+                    switch (authorization.Status)
+                    {
+                        case AuthorizationStatus.Valid:
+                            return;
+                        case AuthorizationStatus.Pending:
+                            await Task.Delay(delay);
+                            continue;
+                        case AuthorizationStatus.Invalid:
+                            throw InvalidAuthorizationError(authorization);
+                        case AuthorizationStatus.Revoked:
+                            throw new InvalidOperationException($"The authorization to verify domainName '{domainName}' has been revoked.");
+                        case AuthorizationStatus.Expired:
+                            throw new InvalidOperationException($"The authorization to verify domainName '{domainName}' has expired.");
+                        default:
+                            throw new ArgumentOutOfRangeException("Unexpected response from server while validating domain ownership.");
+                    }
+                }
+
+                throw new TimeoutException("Timed out waiting for domain ownership validation.");
+            }
+            finally
+            {
+                if (_tlsAlpnChallengeResponder.IsEnabled)
+                {
+                    // cleanup after authorization is done to skip unnecessary cert lookup on all incoming SSL connections
+                    _tlsAlpnChallengeResponder.DiscardChallenge(domainName);
                 }
             }
-
-            throw new TimeoutException("Timed out waiting for domain ownership validation.");
         }
 
         private async Task PrepareHttpChallengeResponseAsync(
@@ -281,6 +300,22 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             await _appStarted.Task;
 
             await httpChallenge.Validate();
+        }
+
+        private async Task PrepareTlsAlpnChallengeResponseAsync(
+            IAuthorizationContext authorizationContext,
+            string domainName,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tlsAlpnChallenge = await authorizationContext.TlsAlpn();
+
+            _tlsAlpnChallengeResponder.PrepareChallengeCert(domainName, tlsAlpnChallenge.KeyAuthz);
+
+            await _appStarted.Task;
+
+            await tlsAlpnChallenge.Validate();
         }
 
         private Exception InvalidAuthorizationError(Authorization authorization)

--- a/src/LetsEncrypt/Internal/CertificateFactory.cs
+++ b/src/LetsEncrypt/Internal/CertificateFactory.cs
@@ -295,10 +295,10 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             var keyAuth = httpChallenge.KeyAuthz;
             _challengeStore.AddChallengeResponse(httpChallenge.Token, keyAuth);
 
-            // ensure the server has started before requesting validation of HTTP challenge
             _logger.LogTrace("Waiting for server to start accepting HTTP requests");
             await _appStarted.Task;
 
+            _logger.LogTrace("Requesting server to validate HTTP challenge");
             await httpChallenge.Validate();
         }
 
@@ -313,8 +313,10 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
 
             _tlsAlpnChallengeResponder.PrepareChallengeCert(domainName, tlsAlpnChallenge.KeyAuthz);
 
+            _logger.LogTrace("Waiting for server to start accepting HTTP requests");
             await _appStarted.Task;
 
+            _logger.LogTrace("Requesting server to validate TLS/ALPN challenge");
             await tlsAlpnChallenge.Validate();
         }
 

--- a/src/LetsEncrypt/Internal/KestrelOptionsSetup.cs
+++ b/src/LetsEncrypt/Internal/KestrelOptionsSetup.cs
@@ -10,16 +10,24 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
     internal class KestrelOptionsSetup : IConfigureOptions<KestrelServerOptions>
     {
         private readonly CertificateSelector _certificateSelector;
+        private readonly TlsAlpnChallengeResponder _tlsAlpnChallengeResponder;
 
-        public KestrelOptionsSetup(CertificateSelector certificateSelector)
+        public KestrelOptionsSetup(CertificateSelector certificateSelector, TlsAlpnChallengeResponder tlsAlpnChallengeResponder)
         {
             _certificateSelector = certificateSelector ?? throw new ArgumentNullException(nameof(certificateSelector));
+            _tlsAlpnChallengeResponder = tlsAlpnChallengeResponder ?? throw new ArgumentNullException(nameof(tlsAlpnChallengeResponder));
         }
 
         public void Configure(KestrelServerOptions options)
         {
             options.ConfigureHttpsDefaults(o =>
             {
+#if NETCOREAPP3_0
+                o.OnAuthenticate = _tlsAlpnChallengeResponder.OnSslAuthenticate;
+#elif NETSTANDARD2_0
+#else
+#error Update TFMs
+#endif
                 o.ServerCertificateSelector = _certificateSelector.Select;
             });
         }

--- a/src/LetsEncrypt/Internal/TlsAlpnChallengeResponder.cs
+++ b/src/LetsEncrypt/Internal/TlsAlpnChallengeResponder.cs
@@ -5,40 +5,52 @@ using System;
 using System.Net.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using System.Threading;
 using McMaster.AspNetCore.LetsEncrypt.Internal.IO;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging;
+using Org.BouncyCastle.Asn1;
 
 namespace McMaster.AspNetCore.LetsEncrypt.Internal
 {
     /// <summary>
-    /// Implements https://tools.ietf.org/html/rfc8737
+    /// Implements https://tools.ietf.org/html/rfc8737. This validates domain ownership by responding to
+    /// TLS requests using a special self-signed certificate.
     /// </summary>
     internal class TlsAlpnChallengeResponder
     {
         // See RFC8737 section 6.1
-        private static readonly Oid s_id_pe_acmeIdentifier = new Oid("1.3.6.1.5.5.7.1.31");
+        private static readonly Oid s_acmeExtensionOid = new Oid("1.3.6.1.5.5.7.1.31");
         private const string PROTOCOL_NAME = "acme-tls/1";
 #if NETCOREAPP3_0
-        public static readonly SslApplicationProtocol AcmeTlsProtocol = new SslApplicationProtocol(PROTOCOL_NAME);
+        private static readonly SslApplicationProtocol s_acmeTlsProtocol = new SslApplicationProtocol(PROTOCOL_NAME);
 #endif
         private readonly IClock _clock;
+        private readonly ILogger<TlsAlpnChallengeResponder> _logger;
         private readonly CertificateSelector _certificateSelector;
         private int _openChallenges = 0;
 
-        public TlsAlpnChallengeResponder(CertificateSelector certificateSelector, IClock clock)
+        public TlsAlpnChallengeResponder(
+            CertificateSelector certificateSelector,
+            IClock clock,
+            ILogger<TlsAlpnChallengeResponder> logger)
         {
             _certificateSelector = certificateSelector ?? throw new ArgumentNullException(nameof(certificateSelector));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
 #if NETSTANDARD2_0
+
         // TLS ALPN not supported on .NET Standard. Requires .NET Core 3
         public bool IsEnabled => false;
+
         public void PrepareChallengeCert(string domainName, string keyAuthorization)
         {
             throw new PlatformNotSupportedException();
         }
+
 #elif NETCOREAPP3_0
         public bool IsEnabled => true;
 
@@ -46,13 +58,19 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
         {
             if (_openChallenges > 0)
             {
-                options.ApplicationProtocols.Add(AcmeTlsProtocol);
+                options.ApplicationProtocols.Add(s_acmeTlsProtocol);
             }
         }
 
+        /// <summary>
+        /// Generates a self-signed cert per RFC 8737 spec.
+        /// </summary>
+        /// <param name="domainName">the domain name</param>
+        /// <param name="keyAuthorization">token to be included in self-signed cert</param>
         public void PrepareChallengeCert(string domainName, string keyAuthorization)
         {
-            Interlocked.Increment(ref _openChallenges);
+            _logger.LogTrace("Creating ALPN self-signed cert for {domainName} and key authz {keyAuth}",
+                domainName, keyAuthorization);
 
             var key = RSA.Create(2048);
             var csr = new CertificateRequest(
@@ -81,23 +99,27 @@ namespace McMaster.AspNetCore.LetsEncrypt.Internal
             csr.CertificateExtensions.Add(sanBuilder.Build());
 
             // adds acmeIdentifier extension (critical = true)
-            using var hash = SHA256.Create();
-            var acmeExtensionData = hash.ComputeHash(Convert.FromBase64String(keyAuthorization));
-            var acmeIdentifierExtension = new X509Extension(s_id_pe_acmeIdentifier, acmeExtensionData, critical: true);
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(keyAuthorization));
+            var extensionData = new DerOctetString(hash).GetDerEncoded();
+            var acmeIdentifierExtension = new X509Extension(s_acmeExtensionOid, extensionData, critical: true);
             csr.CertificateExtensions.Add(acmeIdentifierExtension);
 
             // This cert is ephemeral and does not need to be stored for reuse later
-            var cert = csr.CreateSelfSigned(_clock.Now.AddMinutes(-1), _clock.Now.AddDays(1));
+            var cert = csr.CreateSelfSigned(_clock.Now.AddDays(-1), _clock.Now.AddDays(1));
 
+            Interlocked.Increment(ref _openChallenges);
             _certificateSelector.AddChallengeCert(cert);
         }
 #else
-#error Target framework must be udpated
+#error Update TFMs
 #endif
 
         public void DiscardChallenge(string domainName)
         {
             Interlocked.Decrement(ref _openChallenges);
+
+            _logger.LogTrace("Clearing ALPN cert for {domainName}", domainName);
 
             _certificateSelector.ClearChallengeCert(domainName);
         }

--- a/src/LetsEncrypt/Internal/TlsAlpnChallengeResponder.cs
+++ b/src/LetsEncrypt/Internal/TlsAlpnChallengeResponder.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using McMaster.AspNetCore.LetsEncrypt.Internal.IO;
+using Microsoft.AspNetCore.Connections;
+
+namespace McMaster.AspNetCore.LetsEncrypt.Internal
+{
+    /// <summary>
+    /// Implements https://tools.ietf.org/html/rfc8737
+    /// </summary>
+    internal class TlsAlpnChallengeResponder
+    {
+        // See RFC8737 section 6.1
+        private static readonly Oid s_id_pe_acmeIdentifier = new Oid("1.3.6.1.5.5.7.1.31");
+        private const string PROTOCOL_NAME = "acme-tls/1";
+#if NETCOREAPP3_0
+        public static readonly SslApplicationProtocol AcmeTlsProtocol = new SslApplicationProtocol(PROTOCOL_NAME);
+#endif
+        private readonly IClock _clock;
+        private readonly CertificateSelector _certificateSelector;
+        private int _openChallenges = 0;
+
+        public TlsAlpnChallengeResponder(CertificateSelector certificateSelector, IClock clock)
+        {
+            _certificateSelector = certificateSelector ?? throw new ArgumentNullException(nameof(certificateSelector));
+            _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        }
+
+#if NETSTANDARD2_0
+        // TLS ALPN not supported on .NET Standard. Requires .NET Core 3
+        public bool IsEnabled => false;
+        public void PrepareChallengeCert(string domainName, string keyAuthorization)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#elif NETCOREAPP3_0
+        public bool IsEnabled => true;
+
+        public void OnSslAuthenticate(ConnectionContext context, SslServerAuthenticationOptions options)
+        {
+            if (_openChallenges > 0)
+            {
+                options.ApplicationProtocols.Add(AcmeTlsProtocol);
+            }
+        }
+
+        public void PrepareChallengeCert(string domainName, string keyAuthorization)
+        {
+            Interlocked.Increment(ref _openChallenges);
+
+            var key = RSA.Create(2048);
+            var csr = new CertificateRequest(
+                "CN=" + domainName,
+                key,
+                HashAlgorithmName.SHA512,
+                RSASignaturePadding.Pkcs1);
+
+            /*
+            RFC 8737 Section 3
+
+            The client prepares for validation by constructing a self-signed
+            certificate that MUST contain an acmeIdentifier extension and a
+            subjectAlternativeName extension [RFC5280].  The
+            subjectAlternativeName extension MUST contain a single dNSName entry
+            where the value is the domain name being validated.  The
+            acmeIdentifier extension MUST contain the SHA-256 digest [FIPS180-4]
+            of the key authorization [RFC8555] for the challenge.  The
+            acmeIdentifier extension MUST be critical so that the certificate
+            isn't inadvertently used by non-ACME software.
+            */
+
+            // adds subjectAlternativeName
+            var sanBuilder = new SubjectAlternativeNameBuilder();
+            sanBuilder.AddDnsName(domainName);
+            csr.CertificateExtensions.Add(sanBuilder.Build());
+
+            // adds acmeIdentifier extension (critical = true)
+            using var hash = SHA256.Create();
+            var acmeExtensionData = hash.ComputeHash(Convert.FromBase64String(keyAuthorization));
+            var acmeIdentifierExtension = new X509Extension(s_id_pe_acmeIdentifier, acmeExtensionData, critical: true);
+            csr.CertificateExtensions.Add(acmeIdentifierExtension);
+
+            // This cert is ephemeral and does not need to be stored for reuse later
+            var cert = csr.CreateSelfSigned(_clock.Now.AddMinutes(-1), _clock.Now.AddDays(1));
+
+            _certificateSelector.AddChallengeCert(cert);
+        }
+#else
+#error Target framework must be udpated
+#endif
+
+        public void DiscardChallenge(string domainName)
+        {
+            Interlocked.Decrement(ref _openChallenges);
+
+            _certificateSelector.ClearChallengeCert(domainName);
+        }
+    }
+}

--- a/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
+++ b/src/LetsEncrypt/LetsEncryptServiceCollectionExtensions.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddSingleton<ICertificateSource>(x => x.GetRequiredService<X509CertStore>())
                 .AddSingleton<ICertificateRepository>(x => x.GetRequiredService<X509CertStore>())
                 .AddSingleton<HttpChallengeResponseMiddleware>()
+                .AddSingleton<TlsAlpnChallengeResponder>()
                 .AddSingleton<IStartupFilter, HttpChallengeStartupFilter>();
 
             services.AddSingleton<IConfigureOptions<LetsEncryptOptions>>(services =>

--- a/src/LetsEncrypt/McMaster.AspNetCore.LetsEncrypt.csproj
+++ b/src/LetsEncrypt/McMaster.AspNetCore.LetsEncrypt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/src/LetsEncrypt/releasenotes.props
+++ b/src/LetsEncrypt/releasenotes.props
@@ -5,6 +5,7 @@ Features:
 
 * @mbican: Automatically renew certificates 30 days before expiration (PR #73)
 * @natemcmaster: persist account information between server restarts (PR #67)
+* @natemcmaster: (.NET Core 3+) support HTTPS-only config by implementing TLS/ALPN challenge validation (RFC 8737)
 
 Fixes:
 

--- a/test/LetsEncrypt.UnitTests/CertificateSelectorTests.cs
+++ b/test/LetsEncrypt.UnitTests/CertificateSelectorTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using McMaster.AspNetCore.LetsEncrypt;
 using McMaster.AspNetCore.LetsEncrypt.Internal;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -19,7 +20,9 @@ namespace LetsEncrypt.UnitTests
             const string CommonName = "selector.letsencrypt.natemcmaster.com";
 
             var testCert = CreateTestCert(CommonName);
-            var selector = new CertificateSelector(Options.Create(new LetsEncryptOptions()));
+            var selector = new CertificateSelector(
+                Options.Create(new LetsEncryptOptions()),
+                NullLogger<CertificateSelector>.Instance);
 
             selector.Add(testCert);
 
@@ -37,7 +40,9 @@ namespace LetsEncrypt.UnitTests
                 "san3.letsencrypt.natemcmaster.com",
             };
             var testCert = CreateTestCert(domainNames);
-            var selector = new CertificateSelector(Options.Create(new LetsEncryptOptions()));
+            var selector = new CertificateSelector(
+                Options.Create(new LetsEncryptOptions()),
+                NullLogger<CertificateSelector>.Instance);
 
             selector.Add(testCert);
 
@@ -54,7 +59,9 @@ namespace LetsEncrypt.UnitTests
             var fiveDays = CreateTestCert(CommonName, DateTimeOffset.Now.AddDays(5));
             var tenDays = CreateTestCert(CommonName, DateTimeOffset.Now.AddDays(10));
 
-            var selector = new CertificateSelector(Options.Create(new LetsEncryptOptions()));
+            var selector = new CertificateSelector(
+                Options.Create(new LetsEncryptOptions()),
+                NullLogger<CertificateSelector>.Instance);
 
             selector.Add(fiveDays);
             selector.Add(tenDays);

--- a/test/LetsEncrypt.UnitTests/StartupCertificateLoaderTests.cs
+++ b/test/LetsEncrypt.UnitTests/StartupCertificateLoaderTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using McMaster.AspNetCore.LetsEncrypt;
 using McMaster.AspNetCore.LetsEncrypt.Internal;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -18,7 +19,10 @@ namespace LetsEncrypt.UnitTests
             var testCert = new X509Certificate2();
             IEnumerable<X509Certificate2> certs = new[] { testCert };
 
-            var selector = new Mock<CertificateSelector>(Options.Create(new LetsEncryptOptions()));
+            var selector = new Mock<CertificateSelector>(
+                Options.Create(new LetsEncryptOptions()),
+                NullLogger<CertificateSelector>.Instance);
+
             selector
                 .Setup(s => s.Add(testCert))
                 .Verifiable();


### PR DESCRIPTION
This removes the requirement to serve unencrypted HTTP traffic to verify domain ownership by implementing TLS-ALPN-01 verification. See https://letsencrypt.org/docs/challenge-types/#tls-alpn-01 and https://tools.ietf.org/html/rfc8737.

Only works for servers running .NET Core 3+.

Resolves #75 
