### PR TITLE
Ensure failure in one cert repository doesn't prevent saving the cert to others

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix>rc</VersionSuffix>
     <IncludePreReleaseLabelInPackageVersion Condition="'$(IsStableBuild)' != 'true'">true</IncludePreReleaseLabelInPackageVersion>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">$([MSBuild]::ValueOrDefault($(BUILD_NUMBER), 0))</BuildNumber>

--- a/src/LetsEncrypt/releasenotes.props
+++ b/src/LetsEncrypt/releasenotes.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageReleaseNotes Condition="'$(VersionPrefix)' == '0.5.0'">
+    <PackageReleaseNotes Condition="$(VersionPrefix.StartsWith('0.5.'))">
 Features:
 
 * @mbican: Automatically renew certificates 30 days before expiration (PR #73)
@@ -9,8 +9,14 @@ Features:
 
 Fixes:
 
+0.5.0
+
 * @natemcmaster: fix bug in responding to HTTP challenges (PR #74)
 * @dv00d00: workaround dotnet/aspnetcore#21183 by preloading intermediate CA certificates (PR #81)
+
+0.5.1
+
+* @natemcmaster: ensure failure in one cert repository doesn't prevent saving the cert to others (PR #82)
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="'$(VersionPrefix)' == '0.4.0'">
 Features:


### PR DESCRIPTION
Noticed this in setting up my server. Saving certs to x509 store failed b/c I was using a system account in Linux. Consequently, the persistence of the cert to disk never ran.

This should run each save task in isolation and then raise an aggregate error at the end.