### PR TITLE
Drop .NET Core 2.1 tests, add .NET 6 tests, and upgrade test dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-format": {
-      "version": "5.1.225507",
+      "version": "5.1.250801",
       "commands": [
         "dotnet-format"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core 2.1
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "2.1.x"
       - name: Setup .NET Core 3.1
         uses: actions/setup-dotnet@v1
         with:

--- a/src/LettuceEncrypt/LettuceEncrypt.csproj
+++ b/src/LettuceEncrypt/LettuceEncrypt.csproj
@@ -26,10 +26,6 @@ This only works with Kestrel, which is the default server configuration for ASP.
     <PackageReference Include="Certes" Version="2.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />

--- a/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
+++ b/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
@@ -16,10 +16,6 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
-#if NETCOREAPP2_1
-using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
-#endif
-
 namespace LettuceEncrypt.Azure.UnitTests
 {
     public class AzureKeyVaultTests

--- a/test/LettuceEncrypt.Azure.UnitTests/ConfigurationBindingTests.cs
+++ b/test/LettuceEncrypt.Azure.UnitTests/ConfigurationBindingTests.cs
@@ -61,7 +61,6 @@ namespace LettuceEncrypt.Azure.UnitTests
             Assert.Equal("https://incode/", options.Value.AzureKeyVaultEndpoint);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Theory]
         [InlineData(null)]
         [InlineData("")]
@@ -79,6 +78,5 @@ namespace LettuceEncrypt.Azure.UnitTests
             var ex = Assert.Throws<OptionsValidationException>(() => options.Value);
             Assert.Contains(nameof(AzureKeyVaultLettuceEncryptOptions.AzureKeyVaultEndpoint), ex.Message);
         }
-#endif
     }
 }

--- a/test/LettuceEncrypt.Azure.UnitTests/LettuceEncrypt.Azure.UnitTests.csproj
+++ b/test/LettuceEncrypt.Azure.UnitTests/LettuceEncrypt.Azure.UnitTests.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
+++ b/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
@@ -66,7 +66,6 @@ namespace LettuceEncrypt.Tests
             Assert.Equal(challengeType, options.AllowedChallengeTypes);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void DoesNotSupportWildcardDomains()
         {
@@ -76,7 +75,6 @@ namespace LettuceEncrypt.Tests
                     ["LettuceEncrypt:DomainNames:0"] = "*.natemcmaster.com",
                 }));
         }
-#endif
 
         private LettuceEncryptOptions ParseOptions(Dictionary<string, string> input)
         {

--- a/test/LettuceEncrypt.UnitTests/DefaultCertificateAuthorityConfigurationTests.cs
+++ b/test/LettuceEncrypt.UnitTests/DefaultCertificateAuthorityConfigurationTests.cs
@@ -9,10 +9,6 @@ using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-#if NETCOREAPP2_1
-using Environments = Microsoft.Extensions.Hosting.EnvironmentName;
-#endif
-
 namespace LettuceEncrypt.UnitTests
 {
     public class DefaultCertificateAuthorityConfigurationTests

--- a/test/LettuceEncrypt.UnitTests/DeveloperCertLoaderTests.cs
+++ b/test/LettuceEncrypt.UnitTests/DeveloperCertLoaderTests.cs
@@ -8,10 +8,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
-#if NETCOREAPP2_1
-using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
-
-#endif
 
 
 namespace LettuceEncrypt.UnitTests

--- a/test/LettuceEncrypt.UnitTests/FileSystemAccountStoreTests.cs
+++ b/test/LettuceEncrypt.UnitTests/FileSystemAccountStoreTests.cs
@@ -15,10 +15,6 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
-#if NETCOREAPP2_1
-using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
-#endif
-
 namespace LettuceEncrypt.UnitTests
 {
     public class FileSystemAccountStoreTests : IDisposable

--- a/test/LettuceEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
+++ b/test/LettuceEncrypt.UnitTests/FileSystemCertificateRepoTests.cs
@@ -12,10 +12,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
 using Xunit;
-#if NETCOREAPP2_1
-using IHostEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
-
-#endif
 
 namespace LettuceEncrypt.UnitTests
 {

--- a/test/LettuceEncrypt.UnitTests/HttpChallengeResponseMiddlewareTests.cs
+++ b/test/LettuceEncrypt.UnitTests/HttpChallengeResponseMiddlewareTests.cs
@@ -10,10 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 using Xunit;
-#if NETCOREAPP2_1
-using ApplicationBuilder = Microsoft.AspNetCore.Builder.Internal.ApplicationBuilder;
-
-#endif
 
 namespace LettuceEncrypt.UnitTests
 {

--- a/test/LettuceEncrypt.UnitTests/LettuceEncrypt.UnitTests.csproj
+++ b/test/LettuceEncrypt.UnitTests/LettuceEncrypt.UnitTests.csproj
@@ -1,17 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.0.3" />
+    <PackageReference Include="coverlet.collector" Version="3.1.0" />
     <PackageReference Include="McMaster.Extensions.Xunit" Version="0.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)' == 'netcoreapp2.1'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Test cleanup, no functional changes