### PR TITLE
feature: add certificate-per-domain functionality

### DIFF
--- a/samples/KeyVault/appsettings.Production.json
+++ b/samples/KeyVault/appsettings.Production.json
@@ -1,9 +1,11 @@
 {
   "LettuceEncrypt": {
     "DomainNames": [
-      "example.com",
-      "www.example.com",
-      "www2.example.com"
+      [
+        "example.com",
+        "www.example.com",
+        "www2.example.com"
+      ]
     ],
     "AzureKeyVault": {
       "AzureKeyVaultEndpoint": "https://my-production-secrets.vault.azure.net"

--- a/samples/KeyVault/appsettings.Staging.json
+++ b/samples/KeyVault/appsettings.Staging.json
@@ -1,7 +1,7 @@
 {
   "LettuceEncrypt": {
     "DomainNames": [
-      "staging.example.com"
+      [ "staging.example.com" ]
     ],
     "AzureKeyVault": {
       "AzureKeyVaultEndpoint": "https://my-staging-secrets.vault.azure.net"

--- a/samples/Web/appsettings.Production.json
+++ b/samples/Web/appsettings.Production.json
@@ -1,9 +1,11 @@
 {
   "LettuceEncrypt": {
     "DomainNames": [
-      "example.com",
-      "www.example.com",
-      "www2.example.com"
+      [
+        "example.com",
+        "www.example.com",
+        "www2.example.com"
+      ]
     ]
   }
 }

--- a/samples/Web/appsettings.Staging.json
+++ b/samples/Web/appsettings.Staging.json
@@ -1,7 +1,7 @@
 {
   "LettuceEncrypt": {
     "DomainNames": [
-      "staging.example.com"
+      [ "staging.example.com" ]
     ],
     "UseStagingServer": true
   }

--- a/src/LettuceEncrypt.Azure/Internal/AzureKeyVaultCertificateRepository.cs
+++ b/src/LettuceEncrypt.Azure/Internal/AzureKeyVaultCertificateRepository.cs
@@ -34,7 +34,7 @@ internal class AzureKeyVaultCertificateRepository : ICertificateRepository, ICer
     {
         var certs = new List<X509Certificate2>();
 
-        foreach (var domain in _encryptOptions.Value.DomainNames)
+        foreach (var domain in _encryptOptions.Value.DomainNames.SelectMany(domainName => domainName))
         {
             var cert = await GetCertificateWithPrivateKeyAsync(domain, cancellationToken);
 

--- a/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
@@ -91,6 +91,8 @@ internal class AcmeCertificateLoader : BackgroundService
     }
 
     private bool LettuceEncryptDomainNamesWereConfigured()
-        => _options.Value.DomainNames
-            .Any(w => !string.Equals("localhost", w, StringComparison.OrdinalIgnoreCase));
+    {
+        return _options.Value.DomainNames.All(domains =>
+                    domains.Any(w => !string.Equals("localhost", w, StringComparison.OrdinalIgnoreCase)));
+    }
 }

--- a/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
@@ -7,11 +7,12 @@ using Microsoft.Extensions.Options;
 
 namespace LettuceEncrypt.Internal.AcmeStates;
 
-internal class CheckForRenewalState : AcmeState
+internal class CheckForRenewalState : SyncAcmeState
 {
     private readonly ILogger<CheckForRenewalState> _logger;
     private readonly IOptions<LettuceEncryptOptions> _options;
     private readonly CertificateSelector _selector;
+    private readonly DomainNamesEnumerator _domainNamesEnumerator;
     private readonly IClock _clock;
 
     public CheckForRenewalState(
@@ -19,47 +20,45 @@ internal class CheckForRenewalState : AcmeState
         ILogger<CheckForRenewalState> logger,
         IOptions<LettuceEncryptOptions> options,
         CertificateSelector selector,
+        DomainNamesEnumerator domainNamesEnumerator,
         IClock clock) : base(context)
     {
         _logger = logger;
         _options = options;
         _selector = selector;
+        _domainNamesEnumerator = domainNamesEnumerator;
         _clock = clock;
     }
 
-    public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+    public override IAcmeState MoveNext()
     {
-        while (!cancellationToken.IsCancellationRequested)
+        var checkPeriod = _options.Value.RenewalCheckPeriod;
+        var daysInAdvance = _options.Value.RenewDaysInAdvance;
+        if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
         {
-            var checkPeriod = _options.Value.RenewalCheckPeriod;
-            var daysInAdvance = _options.Value.RenewDaysInAdvance;
-            if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
-            {
-                _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
-                    nameof(AcmeCertificateLoader));
-                return MoveTo<TerminalState>();
-            }
-
-            var domainNames = _options.Value.DomainNames;
-            if (_logger.IsEnabled(LogLevel.Debug))
-            {
-                _logger.LogDebug("Checking certificates' renewals for {hostname}",
-                    string.Join(", ", domainNames));
-            }
-
-            foreach (var domainName in domainNames)
-            {
-                if (!_selector.TryGet(domainName, out var cert)
-                    || cert == null
-                    || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
-                {
-                    return MoveTo<BeginCertificateCreationState>();
-                }
-            }
-
-            await Task.Delay(checkPeriod.Value, cancellationToken);
+            _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
+                                   nameof(AcmeCertificateLoader));
+            return MoveTo<TerminalState>();
         }
 
-        return MoveTo<TerminalState>();
+        var domainNames = _domainNamesEnumerator.Current;
+
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug("Checking certificates' renewals for {hostname}",
+                             string.Join(", ", domainNames));
+        }
+
+        foreach (var domainName in domainNames)
+        {
+            if (!_selector.TryGet(domainName, out var cert)
+                || cert == null
+                || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
+            {
+                return MoveTo<BeginCertificateCreationState>();
+            }
+        }
+
+        return MoveTo<ServerStartupState>();
     }
 }

--- a/src/LettuceEncrypt/Internal/AcmeStates/WaitState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/WaitState.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using LettuceEncrypt.Internal.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LettuceEncrypt.Internal.AcmeStates;
+
+internal class WaitState : AcmeState
+{
+    private readonly ILogger<WaitState> _logger;
+    private readonly IOptions<LettuceEncryptOptions> _options;
+    private readonly CertificateSelector _selector;
+    private readonly IClock _clock;
+
+    public WaitState(
+        AcmeStateMachineContext context,
+        ILogger<WaitState> logger,
+        IOptions<LettuceEncryptOptions> options,
+        CertificateSelector selector,
+        IClock clock) : base(context)
+    {
+        _logger = logger;
+        _options = options;
+        _selector = selector;
+        _clock = clock;
+    }
+
+    public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+    {
+        var checkPeriod = _options.Value.RenewalCheckPeriod;
+        if (!checkPeriod.HasValue)
+        {
+            _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
+                                   nameof(AcmeCertificateLoader));
+            return MoveTo<TerminalState>();
+        }
+
+        await Task.Delay(checkPeriod.Value, cancellationToken);
+
+        return MoveTo<ServerStartupState>();
+    }
+}

--- a/src/LettuceEncrypt/Internal/DomainNamesEnumerator.cs
+++ b/src/LettuceEncrypt/Internal/DomainNamesEnumerator.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections;
+using Microsoft.Extensions.Options;
+
+namespace LettuceEncrypt.Internal;
+
+internal class DomainNamesEnumerator : IEnumerator
+{
+    private readonly string[][] _domains;
+
+    private int _position = -1;
+
+    public DomainNamesEnumerator(IOptions<LettuceEncryptOptions> options)
+    {
+        _domains = options.Value.DomainNames;
+    }
+
+    public bool MoveNext()
+    {
+        _position++;
+        return _position < _domains.Length;
+    }
+
+    public void Reset()
+    {
+        _position = -1;
+    }
+
+    object IEnumerator.Current
+    {
+        get
+        {
+            return Current;
+        }
+    }
+
+    public string[] Current
+    {
+        get
+        {
+            try
+            {
+                return _domains[_position];
+            }
+            catch (IndexOutOfRangeException)
+            {
+                throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/OptionsValidation.cs
+++ b/src/LettuceEncrypt/Internal/OptionsValidation.cs
@@ -13,7 +13,7 @@ internal class OptionsValidation : IValidateOptions<LettuceEncryptOptions>
         if (options.AllowedChallengeTypes == ChallengeType.Dns01)
             return ValidateOptionsResult.Success;
 
-        foreach (var dnsName in options.DomainNames)
+        foreach (var dnsName in options.DomainNames.SelectMany(domainName => domainName))
         {
             if (dnsName.Contains('*'))
             {

--- a/src/LettuceEncrypt/Internal/X509CertStore.cs
+++ b/src/LettuceEncrypt/Internal/X509CertStore.cs
@@ -25,7 +25,7 @@ internal class X509CertStore : ICertificateSource, ICertificateRepository, IDisp
 
     public Task<IEnumerable<X509Certificate2>> GetCertificatesAsync(CancellationToken cancellationToken)
     {
-        var domainNames = new HashSet<string>(_options.Value.DomainNames);
+        var domainNames = new HashSet<string>(_options.Value.DomainNames.SelectMany(domainName => domainName));
         var result = new List<X509Certificate2>();
         var certs = _store.Certificates.Find(X509FindType.FindByTimeValid,
             DateTime.Now,

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -11,13 +11,16 @@ namespace LettuceEncrypt;
 /// </summary>
 public class LettuceEncryptOptions
 {
-    private string[] _domainNames = Array.Empty<string>();
+    private string[][] _domainNames = Array.Empty<string[]>();
     private bool? _useStagingServer;
 
     /// <summary>
     /// The domain names for which to generate certificates.
+    /// An array of arrays of domain names for which to generate certificates.
+    /// The domains in each child array share a single certificate.
+    /// Each child array will have its own certificate.
     /// </summary>
-    public string[] DomainNames
+    public string[][] DomainNames
     {
         get => _domainNames;
         set => _domainNames = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
@@ -78,6 +78,7 @@ public static class LettuceEncryptServiceCollectionExtensions
 
         // The state machine should run in its own scope
         services.AddScoped<AcmeStateMachineContext>();
+        services.AddScoped<DomainNamesEnumerator>();
 
         services.AddSingleton(TerminalState.Singleton);
 
@@ -85,7 +86,8 @@ public static class LettuceEncryptServiceCollectionExtensions
         services
             .AddTransient<ServerStartupState>()
             .AddTransient<CheckForRenewalState>()
-            .AddTransient<BeginCertificateCreationState>();
+            .AddTransient<BeginCertificateCreationState>()
+            .AddTransient<WaitState>();
 
         // PfxBuilderFactory is stateless, so there's no need for a transient registration
         services.AddSingleton<IPfxBuilderFactory, PfxBuilderFactory>();

--- a/src/LettuceEncrypt/PublicAPI.Shipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Shipped.txt
@@ -52,7 +52,7 @@ LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.get -> string![]!
 LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.set -> void
 LettuceEncrypt.LettuceEncryptOptions.AllowedChallengeTypes.get -> LettuceEncrypt.Acme.ChallengeType
 LettuceEncrypt.LettuceEncryptOptions.AllowedChallengeTypes.set -> void
-LettuceEncrypt.LettuceEncryptOptions.DomainNames.get -> string![]!
+LettuceEncrypt.LettuceEncryptOptions.DomainNames.get -> string![]![]!
 LettuceEncrypt.LettuceEncryptOptions.DomainNames.set -> void
 LettuceEncrypt.LettuceEncryptOptions.EabCredentials.get -> LettuceEncrypt.Acme.EabCredentials!
 LettuceEncrypt.LettuceEncryptOptions.EabCredentials.set -> void

--- a/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
+++ b/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
@@ -71,14 +71,14 @@ public class AzureKeyVaultTests
         certClientFactory.Setup(c => c.Create()).Returns(certClient.Object);
         var options = Options.Create(new LettuceEncryptOptions());
 
-        options.Value.DomainNames = new[] { Domain1, Domain2 };
+        options.Value.DomainNames = new[] { new[] { Domain1, Domain2 } };
 
         var repository = new AzureKeyVaultCertificateRepository(
             certClientFactory.Object,
             Mock.Of<ISecretClientFactory>(),
             options,
             NullLogger<AzureKeyVaultCertificateRepository>.Instance);
-        foreach (var domain in options.Value.DomainNames)
+        foreach (var domain in options.Value.DomainNames.First())
         {
             var certificateToSave = TestUtils.CreateTestCert(domain);
             await repository.SaveAsync(certificateToSave, CancellationToken.None);
@@ -101,7 +101,7 @@ public class AzureKeyVaultTests
         secretClientFactory.Setup(c => c.Create()).Returns(secretClient.Object);
         var options = Options.Create(new LettuceEncryptOptions());
 
-        options.Value.DomainNames = new[] { Domain1, Domain2 };
+        options.Value.DomainNames = new[] { new[] { Domain1, Domain2 } };
 
         var repository = new AzureKeyVaultCertificateRepository(
             Mock.Of<ICertificateClientFactory>(),

--- a/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
+++ b/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
@@ -16,15 +16,17 @@ public class ConfigurationBindingTests
         var options = ParseOptions(new()
         {
             ["LettuceEncrypt:AcceptTermsOfService"] = "true",
-            ["LettuceEncrypt:DomainNames:0"] = "one.com",
-            ["LettuceEncrypt:DomainNames:1"] = "two.com",
+            ["LettuceEncrypt:DomainNames:0:0"] = "one_one.com",
+            ["LettuceEncrypt:DomainNames:0:1"] = "one_two.com",
+            ["LettuceEncrypt:DomainNames:1:0"] = "two_one.com",
+            ["LettuceEncrypt:DomainNames:1:1"] = "two_two.com",
             ["LettuceEncrypt:AllowedChallengeTypes"] = "Http01",
         });
 
         Assert.True(options.AcceptTermsOfService);
         Assert.Collection(options.DomainNames,
-            one => Assert.Equal("one.com", one),
-            two => Assert.Equal("two.com", two));
+                          one => Assert.Equal(new string[] { "one_one.com", "one_two.com" }, one),
+                          two => Assert.Equal(new string[] { "two_one.com", "two_two.com" }, two));
         Assert.Equal(Acme.ChallengeType.Http01, options.AllowedChallengeTypes);
     }
 
@@ -71,7 +73,7 @@ public class ConfigurationBindingTests
         Assert.Throws<OptionsValidationException>(() =>
             ParseOptions(new()
             {
-                ["LettuceEncrypt:DomainNames:0"] = "*.natemcmaster.com",
+                ["LettuceEncrypt:DomainNames:0:0"] = "*.natemcmaster.com",
             }));
     }
 

--- a/test/LettuceEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LettuceEncrypt.UnitTests/X509CertStoreTests.cs
@@ -40,7 +40,7 @@ public class X509CertStoreTests : IDisposable
     public async Task ItFindsCertByCommonNameAsync()
     {
         var commonName = "x509store.read.test.natemcmaster.com";
-        _options.DomainNames = new[] { commonName };
+        _options.DomainNames = new[] { new[] { commonName } };
         using var x509Store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
         x509Store.Open(OpenFlags.ReadWrite);
         var testCert = CreateTestCert(commonName);
@@ -97,7 +97,7 @@ public class X509CertStoreTests : IDisposable
     public async Task ItReturnsEmptyWhenCantFindCertAsync()
     {
         var commonName = "notfound.test.natemcmaster.com";
-        _options.DomainNames = new[] { commonName };
+        _options.DomainNames = new[] { new[] { commonName } };
         var certs = await _certStore.GetCertificatesAsync(default);
         Assert.Empty(certs);
     }


### PR DESCRIPTION
Added certificate-per-domain functionality.

Fixes #236

### Breaking changes
The **DomainNames** configuration property is now an array of arrays instead of an array. Each child array will have its own certificate.